### PR TITLE
Improve codecov settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,10 +15,9 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: auto
-        threshold: 10%
+        # Informational only — reports patch coverage without failing the check.
+        # The project check enforces actual coverage thresholds.
+        informational: true
 
 comment:
-  layout: "reach, diff, flags, files"
-  behavior: default
-  require_changes: false
+  layout: "condensed_header, condensed_files, condensed_footer"


### PR DESCRIPTION
## Summary

- **Patch coverage check is now informational-only.** Instead of enforcing a threshold on patch coverage, the patch status reports coverage without failing the check. The project-level check continues to enforce actual coverage thresholds.
- **Comment layout updated to condensed format.** Switched from `reach, diff, flags, files` to `condensed_header, condensed_files, condensed_footer` for a more compact PR comment.